### PR TITLE
add auth to create endpoint, new update endpoint

### DIFF
--- a/crud.py
+++ b/crud.py
@@ -9,13 +9,12 @@ from lnbits.core.crud import (
     get_user,
 )
 from lnbits.core.models import Payment
-from lnbits.db import Filters
-
+from lnbits.db import Filters, POSTGRES
 from . import db
-from .models import CreateUserData, User, UserDetailed, UserFilters, Wallet
+from .models import CreateUserData, User, UserDetailed, UserFilters, Wallet, UpdateUserData
 
 
-async def create_usermanager_user(data: CreateUserData) -> UserDetailed:
+async def create_usermanager_user(admin_id: str, data: CreateUserData) -> UserDetailed:
     account = await create_account()
     user = await get_user(account.id)
     assert user, "Newly created user couldn't be retrieved"
@@ -27,7 +26,7 @@ async def create_usermanager_user(data: CreateUserData) -> UserDetailed:
         INSERT INTO usermanager.users (id, name, admin, email, password, extra)
         VALUES (?, ?, ?, ?, ?, ?)
         """,
-        (user.id, data.user_name, data.admin_id, data.email, data.password,
+        (user.id, data.user_name, admin_id, data.email, data.password,
          json.dumps(data.extra) if data.extra else None),
     )
 
@@ -38,7 +37,7 @@ async def create_usermanager_user(data: CreateUserData) -> UserDetailed:
         """,
         (
             wallet.id,
-            data.admin_id,
+            admin_id,
             data.wallet_name,
             user.id,
             wallet.adminkey,
@@ -126,3 +125,28 @@ async def get_usermanager_wallet_transactions(wallet_id: str) -> List[Payment]:
 async def delete_usermanager_wallet(wallet_id: str, user_id: str) -> None:
     await delete_wallet(user_id=user_id, wallet_id=wallet_id)
     await db.execute("DELETE FROM usermanager.wallets WHERE id = ?", (wallet_id,))
+
+
+async def update_usermanager_user(user_id: str, admin_id: str, data: UpdateUserData) -> None:
+    cols = []
+    values = []
+    if data.user_name:
+        cols.append("name = ?")
+        values.append(data.user_name)
+    if data.extra:
+        if db.type == POSTGRES:
+            cols.append("extra = extra::jsonb || ?")
+        else:
+            cols.append("extra = json_patch(extra, ?)")
+        values.append(json.dumps(data.extra))
+    values.append(user_id)
+    values.append(admin_id)
+    await db.execute(
+        f"""
+        UPDATE usermanager.users
+        SET {", ".join(cols)}
+        WHERE id = ? AND admin = ?
+        """,
+        values
+    )
+    return await get_usermanager_user(user_id)

--- a/crud.py
+++ b/crud.py
@@ -9,9 +9,17 @@ from lnbits.core.crud import (
     get_user,
 )
 from lnbits.core.models import Payment
-from lnbits.db import Filters, POSTGRES
+from lnbits.db import POSTGRES, Filters
+
 from . import db
-from .models import CreateUserData, User, UserDetailed, UserFilters, Wallet, UpdateUserData
+from .models import (
+    CreateUserData,
+    UpdateUserData,
+    User,
+    UserDetailed,
+    UserFilters,
+    Wallet,
+)
 
 
 async def create_usermanager_user(admin_id: str, data: CreateUserData) -> UserDetailed:

--- a/models.py
+++ b/models.py
@@ -1,9 +1,11 @@
 from enum import Enum
 from sqlite3 import Row
-from typing import Any, Optional, Type
+from typing import Optional
 
 from fastapi.param_functions import Query
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
+
+from lnbits.db import FilterModel
 
 
 class Operator(Enum):
@@ -35,10 +37,15 @@ class Operator(Enum):
 class CreateUserData(BaseModel):
     user_name: str = Query(..., description="Name of the user")
     wallet_name: str = Query(..., description="Name of the user")
-    admin_id: str = Query(..., description="Id of the user which will administer this new user")
+    #admin_id: str = Query(..., description="Id of the user which will administer this new user")
     email: str = Query("")
     password: str = Query("")
     extra: Optional[dict[str, str]] = Query(default=None)
+
+
+class UpdateUserData(BaseModel):
+    user_name: Optional[str] = Query(default=None, description="Name of the user")
+    extra: Optional[dict[str, str]] = Query(default=None, description='Partial update for extra field')
 
 
 class CreateUserWallet(BaseModel):
@@ -56,7 +63,7 @@ class User(BaseModel):
     extra: Optional[dict[str, str]]
 
 
-class UserFilters(BaseModel):
+class UserFilters(FilterModel):
     id: str
     name: str
     email: Optional[str] = None

--- a/templates/usermanager/index.html
+++ b/templates/usermanager/index.html
@@ -318,7 +318,6 @@
         if (this.userDialog.data.id) {
         } else {
           var data = {
-            admin_id: this.g.user.id,
             user_name: this.userDialog.data.usrname,
             wallet_name: this.userDialog.data.walname,
             email: this.userDialog.data.email,
@@ -337,7 +336,7 @@
           .request(
             'POST',
             '/usermanager/api/v1/users',
-            this.g.user.wallets[0].inkey,
+            this.g.user.wallets[0].adminkey,
             data
           )
           .then(function (response) {

--- a/views_api.py
+++ b/views_api.py
@@ -15,6 +15,7 @@ from lnbits.decorators import (
     require_admin_key,
 )
 from lnbits.helpers import generate_filter_params_openapi
+
 from . import usermanager_ext
 from .crud import (
     create_usermanager_user,
@@ -32,11 +33,11 @@ from .crud import (
 from .models import (
     CreateUserData,
     CreateUserWallet,
+    UpdateUserData,
     User,
     UserDetailed,
     UserFilters,
     Wallet,
-    UpdateUserData,
 )
 
 

--- a/views_api.py
+++ b/views_api.py
@@ -27,6 +27,7 @@ from .crud import (
     get_usermanager_wallet,
     get_usermanager_wallet_transactions,
     get_usermanager_wallets,
+    update_usermanager_user,
 )
 from .models import (
     CreateUserData,
@@ -35,6 +36,7 @@ from .models import (
     UserDetailed,
     UserFilters,
     Wallet,
+    UpdateUserData,
 )
 
 
@@ -84,7 +86,7 @@ async def api_usermanager_users(
     dependencies=[Depends(get_key_type)],
     response_model=UserDetailed
 )
-async def api_usermanager_user(user_id):
+async def api_usermanager_user(user_id: str):
     user = await get_usermanager_user(user_id)
     if not user:
         raise HTTPException(status_code=HTTPStatus.NOT_FOUND, detail='User not found')
@@ -99,8 +101,27 @@ async def api_usermanager_user(user_id):
     response_description="New User",
     response_model=UserDetailed,
 )
-async def api_usermanager_users_create(data: CreateUserData):
-    return await create_usermanager_user(data)
+async def api_usermanager_users_create(
+    data: CreateUserData,
+    info: WalletTypeInfo = Depends(require_admin_key)
+):
+    return await create_usermanager_user(info.wallet.user, data)
+
+
+@usermanager_ext.patch(
+    "/api/v1/users/{user_id}",
+    name="User Update",
+    summary="Update a user",
+    description="Update a user",
+    response_description="Updated user",
+    response_model=UserDetailed,
+)
+async def api_usermanager_users_create(
+    user_id: str,
+    data: UpdateUserData,
+    info: WalletTypeInfo = Depends(require_admin_key)
+):
+    return await update_usermanager_user(user_id, info.wallet.user, data)
 
 
 @usermanager_ext.delete(

--- a/views_api.py
+++ b/views_api.py
@@ -109,7 +109,7 @@ async def api_usermanager_users_create(
     return await create_usermanager_user(info.wallet.user, data)
 
 
-@usermanager_ext.patch(
+@usermanager_ext.put(
     "/api/v1/users/{user_id}",
     name="User Update",
     summary="Update a user",


### PR DESCRIPTION
Add support for updating users, especially useful with the extra column.

Also change the create endpoint to use the wallet key instead of bare id. I'm not entirely sure about this change because it might break for people who are using the endpoint, only providing the admin id and not authenticating with an api key but I feel like it should really be done through an api key (just like the other endpoints).