### PR TITLE
remove json

### DIFF
--- a/migrations.py
+++ b/migrations.py
@@ -37,6 +37,6 @@ async def m002_add_user_attrs_column(db):
     """
     await db.execute(
         """
-        ALTER TABLE usermanager.users ADD COLUMN extra JSON
+        ALTER TABLE usermanager.users ADD COLUMN extra TEXT
     """
     )

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from enum import Enum
+import json
 from sqlite3 import Row
 from typing import Optional
 
@@ -8,36 +8,9 @@ from pydantic import BaseModel
 from lnbits.db import FilterModel
 
 
-class Operator(Enum):
-    GT = "gt"
-    LT = "lt"
-    EQ = "eq"
-    NE = "ne"
-    INCLUDE = "in"
-    EXCLUDE = "ex"
-
-    @property
-    def as_sql(self):
-        if self == Operator.EQ:
-            return "="
-        elif self == Operator.NE:
-            return "!="
-        elif self == Operator.INCLUDE:
-            return "IN"
-        elif self == Operator.EXCLUDE:
-            return "NOT IN"
-        elif self == Operator.GT:
-            return ">"
-        elif self == Operator.LT:
-            return "<"
-        else:
-            raise ValueError('Unknown')
-
-
 class CreateUserData(BaseModel):
     user_name: str = Query(..., description="Name of the user")
     wallet_name: str = Query(..., description="Name of the user")
-    #admin_id: str = Query(..., description="Id of the user which will administer this new user")
     email: str = Query("")
     password: str = Query("")
     extra: Optional[dict[str, str]] = Query(default=None)
@@ -62,12 +35,17 @@ class User(BaseModel):
     password: Optional[str] = None
     extra: Optional[dict[str, str]]
 
+    @classmethod
+    def from_row(cls, row: Row):
+        attrs = dict(row)
+        attrs["extra"] = json.loads(attrs["extra"]) if attrs["extra"] else None
+        return cls(**attrs)
+
 
 class UserFilters(FilterModel):
     id: str
     name: str
     email: Optional[str] = None
-    extra: Optional[dict[str, str]]
 
 
 class Wallet(BaseModel):


### PR DESCRIPTION
since https://github.com/lnbits/lnbits/pull/1697 has been closed, the `extra` column cant be json. I edited the mgiration directly because it wasnt released. Extra filters are now equality only and now use the following schema for simpler processing:

`/usermanager/api/v1/users?extra={"discord_id": "466706956158107649"}`

I removed some dead code in `models.py aswell`