### PR TITLE
refactor: import `update_user_extension `

### DIFF
--- a/views_api.py
+++ b/views_api.py
@@ -5,8 +5,7 @@ from fastapi import Depends, Query
 from pydantic import Json
 from starlette.exceptions import HTTPException
 
-from lnbits.core import update_user_extension
-from lnbits.core.crud import get_user
+from lnbits.core.crud import get_user, update_user_extension
 from lnbits.core.models import Payment
 from lnbits.db import Filters
 from lnbits.decorators import (


### PR DESCRIPTION
`update_user_extension` was imported from a top level module. That module no longer needs it.
Fix: import directly from `crud`